### PR TITLE
fix: only sign image if push is true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,9 @@ inputs:
     required: true
 
   push:
-    description: "Wether or not to push image"
+    description: "Whether or not to push and sign image"
     default: true
+    type: boolean
 
   workload_identity_provider:
     description: "The workload identity provider for google service account impersonation"
@@ -85,6 +86,7 @@ runs:
 
     - name: "Generate SBOM, attest and sign image"
       uses: nais/attest-sign@v1.0.0
+      if: ${{ inputs.push }}
       with:
         image_ref: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         sbom: ${{ inputs.sbom }}

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ inputs:
   push:
     description: "Whether or not to push and sign image"
     default: true
-    type: boolean
 
   workload_identity_provider:
     description: "The workload identity provider for google service account impersonation"


### PR DESCRIPTION
Attempting to sign a non-existent image results in a `No such image` error