### PR TITLE
Build all images for both amd64 and arm64

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,12 @@ inputs:
     default: 'auto-generate-for-me-please.json'
 
   extra_tags:
-    description: 'A list of tags to be applied in addtion to the detailed time+sha-tag and latest-tag'
+    description: 'A list of tags to be applied in addition to the detailed time+sha-tag and latest-tag'
     default: ''
+
+  multi-platform:
+    description: "Build multi-platform images, supporting amd64 and arm64"
+    default: "false"
 
 outputs:
   tag:
@@ -49,6 +53,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
+      if: "${{ inputs.multi-platform == 'true' }}"
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
@@ -78,12 +83,23 @@ runs:
           type=raw,value={{date 'YYYYMMDD-hhmmss' tz='Europe/Oslo'}}-{{sha}}
           type=raw,value=latest
           type=raw,value=${{inputs.extra_tags}}
+
+    - name: "Select platforms"
+      id: multi-platform
+      shell: bash
+      run: |
+        if [[ "${{ inputs.multi-platform }}" == 'true' ]]; then
+          echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+        else
+          echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+        fi
+
     - name: "Build and push"
       id: "build_push"
       uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # ratchet:docker/build-push-action@v3
       with:
         context: .
-        platforms: linux/amd64,linux/arm64
+        platforms: "${{ steps.multi-platform.outputs.platforms }}"
         file: "${{ inputs.dockerfile }}"
         push: ${{ inputs.push }}
         tags: ${{ steps.metadata.outputs.tags }}

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - id: "auth"
       name: "Authenticate to Google Cloud"
       uses: "google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d" # ratchet:google-github-actions/auth@v1.0.0
@@ -77,6 +83,7 @@ runs:
       uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # ratchet:docker/build-push-action@v3
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         file: "${{ inputs.dockerfile }}"
         push: ${{ inputs.push }}
         tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
@jksolbakken påpekte at det å bygge for arm64 gjorde det litt lettere dersom man vil kjøre containeren lokalt på M1 mac av noen grunn, så han har begynt å legge til arm64 bygg rundt forbi.

Tenkte det i så fall kunne være like greit å gjøre det i denne actionen også.

På den annen side, så kan det hende denne tilnærmingen blir for naiv for mange (de fleste) av tingene våre, siden det antageligvis er mer effektivt å bygge arm64 ved hjelp av cross-compile i Go toolchain i steden for å bygge i en VM ... men det igjen er mer jobb å legge til i hvert enkelt repo så vil neppe bli gjort :shrug: 
