### PR TITLE
Salsa

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
     - name: "Generate SBOM, attest and sign image"
       uses: nais/salsa-action@v0.0.3-beta
       with:
-        image_ref: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
+        image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byosbom: ${{ inputs.sbom }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         build-args: ${{ inputs.build_args }}
 
     - name: "Generate SBOM, attest and sign image"
-      uses: nais/salsa-action@v0.0.3-beta
+      uses: nais/salsa-action@main
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byosbom: ${{ inputs.sbom }}

--- a/action.yml
+++ b/action.yml
@@ -50,9 +50,6 @@ outputs:
   version:
     description: "version"
     value: ${{ steps.outputs.outputs.version }}
-  salsa:
-    description: "generated salsa sbom path"
-    value: ${{ steps.outputs.outputs.salsa }}
 
 runs:
   using: "composite"
@@ -94,7 +91,6 @@ runs:
 
     - name: "Generate SBOM, attest and sign image"
       uses: nais/salsa-action@main
-      id: "salsa"
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byo-sbom: ${{ inputs.sbom }}
@@ -108,4 +104,3 @@ runs:
       run: |
         echo "tag=${{ fromJSON(steps.metadata.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
         echo "version=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
-        echo "salsa=${{ steps.salsa.outputs.sbom }}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byo-sbom: ${{ inputs.sbom }}
         build-context: ${{ inputs.salsa_context }}
-        go-main-dir: /cmd/${{ inputs.name }}
+        go-main-dir: ./cmd/${{ inputs.name }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 
     ##- name: "Generate SBOM, attest and sign image"

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byo-sbom: ${{ inputs.sbom }}
         build-context: ${{ inputs.salsa_context }}
-        go-main-dir: ${{ inputs.salsa_context }}/cmd/${{ inputs.name }}
+        go-main-dir: /cmd/${{ inputs.name }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 
     ##- name: "Generate SBOM, attest and sign image"

--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,8 @@ runs:
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byo-sbom: ${{ inputs.sbom }}
-        context: ${{ inputs.salsa_context }}
+        build-context: ${{ inputs.salsa_context }}
+        go-main-dir: ${{ inputs.salsa_context }}/cmd/${{ inputs.name }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 
     ##- name: "Generate SBOM, attest and sign image"

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: 'existing SBOM in cyclonedx format'
     default: ''
 
+  go-maindir:
+    description: 'main directory for go projects'
+    default: '.'
+
+  context:
+    description: 'context for docker build'
+    default: '.'
+
 outputs:
   tag:
     description: "full image tag"
@@ -40,6 +48,9 @@ outputs:
   version:
     description: "version"
     value: ${{ steps.outputs.outputs.version }}
+  salsa:
+    description: "generated salsa sbom path"
+    value: ${{ steps.outputs.outputs.salsa }}
 
 runs:
   using: "composite"
@@ -79,12 +90,20 @@ runs:
         labels: ${{ steps.metadata.outputs.labels }}
         build-args: ${{ inputs.build_args }}
 
+    - name: Set Go Main dir
+      if: ${{ inputs.go-maindir == '' }}
+      shell: bash
+      run: |
+        echo "GOMAINDIR=./cmd/{{ inputs.name }}" >> $GITHUB_ENV
+
     - name: "Generate SBOM, attest and sign image"
       uses: nais/salsa-action@main
+      id: "salsa"
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
-        maindir: ./cmd/${{ inputs.name }}
+        maindir: ${{ env.GOMAINDIR }}
         byosbom: ${{ inputs.sbom }}
+        context: ${{ inputs.context }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 
     ##- name: "Generate SBOM, attest and sign image"
@@ -99,3 +118,4 @@ runs:
       run: |
         echo "tag=${{ fromJSON(steps.metadata.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
         echo "version=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
+        echo "salsa=${{ steps.salsa.outputs.sbom }}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
         build-args: ${{ inputs.build_args }}
 
     - name: "Generate SBOM, attest and sign image"
-      uses: nais/salsa-action@main
+      uses: nais/salsa-action@v0.1
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byo-sbom: ${{ inputs.sbom }}

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,7 @@ runs:
       uses: nais/salsa-action@main
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
+        maindir: ./cmd/${{ inputs.name }}
         byosbom: ${{ inputs.sbom }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 

--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,8 @@ inputs:
     description: 'existing SBOM in cyclonedx format'
     default: ''
 
-  go-maindir:
-    description: 'main directory for go projects'
-    default: '.'
-
   context:
-    description: 'context for docker build'
+    description: 'the context of project to build from sbom from'
     default: '.'
 
 outputs:
@@ -95,7 +91,6 @@ runs:
       id: "salsa"
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
-        go-main-dir: ./cmd/${{ inputs.name }}
         byo-sbom: ${{ inputs.sbom }}
         context: ${{ inputs.context }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,11 @@ inputs:
     default: '.'
     required: false
 
+  go_main_dir:
+    description: 'the main directory for go if the project have multiple go modules'
+    default: ''
+    required: false
+
   extra_tags:
     description: 'A list of tags to be applied in addtion to the detailed time+sha-tag and latest-tag'
     default: ''
@@ -95,7 +100,7 @@ runs:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byo-sbom: ${{ inputs.sbom }}
         build-context: ${{ inputs.salsa_context }}
-        go-main-dir: ./cmd/${{ inputs.name }}
+        go-main-dir: ${{ inputs.go_main_dir }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 
     - name: "Set outputs"

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
       id: "salsa"
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
-        go-main-dir: ./cmd/{{ inputs.name }}
+        go-main-dir: ./cmd/${{ inputs.name }}
         byo-sbom: ${{ inputs.sbom }}
         context: ${{ inputs.context }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,10 @@ inputs:
 
   sbom:
     description: 'existing SBOM in cyclonedx format'
-    default: 'auto-generate-for-me-please.json'
+    default: ''
 
 outputs:
-  tag: 
+  tag:
     description: "full image tag"
     value: ${{ steps.outputs.outputs.tag }}
   version:
@@ -80,10 +80,17 @@ runs:
         build-args: ${{ inputs.build_args }}
 
     - name: "Generate SBOM, attest and sign image"
-      uses: nais/attest-sign@v1.0.0
+      uses: nais/salsa-action@v0.0.3-beta
       with:
         image_ref: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
-        sbom: ${{ inputs.sbom }}
+        byosbom: ${{ inputs.sbom }}
+        google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
+
+    ##- name: "Generate SBOM, attest and sign image"
+    ##  uses: nais/attest-sign@v1.0.0
+    ##  with:
+    ##    image_ref: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
+    ##    sbom: ${{ inputs.sbom }}
 
     - name: "Set outputs"
       id: outputs

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: 'existing SBOM in cyclonedx format'
     default: ''
 
-  context:
+  salsa_context:
     description: 'the context of project to build from sbom from'
     default: '.'
 
@@ -92,7 +92,7 @@ runs:
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
         byo-sbom: ${{ inputs.sbom }}
-        context: ${{ inputs.context }}
+        context: ${{ inputs.salsa_context }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 
     ##- name: "Generate SBOM, attest and sign image"

--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,14 @@ inputs:
     required: false
 
   sbom:
-    description: 'existing SBOM in cyclonedx format'
+    description: 'provide existing sbom with cyclonedx predicate in json format'
     default: ''
+    required: false
 
   salsa_context:
-    description: 'the context of project to build from sbom from'
+    description: 'the context/root of project to build sbom from'
     default: '.'
+    required: false
 
 outputs:
   tag:
@@ -95,12 +97,6 @@ runs:
         build-context: ${{ inputs.salsa_context }}
         go-main-dir: ./cmd/${{ inputs.name }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
-
-    ##- name: "Generate SBOM, attest and sign image"
-    ##  uses: nais/attest-sign@v1.0.0
-    ##  with:
-    ##    image_ref: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
-    ##    sbom: ${{ inputs.sbom }}
 
     - name: "Set outputs"
       id: outputs

--- a/action.yml
+++ b/action.yml
@@ -90,19 +90,13 @@ runs:
         labels: ${{ steps.metadata.outputs.labels }}
         build-args: ${{ inputs.build_args }}
 
-    - name: Set Go Main dir
-      if: ${{ inputs.go-maindir == '' }}
-      shell: bash
-      run: |
-        echo "GOMAINDIR=./cmd/{{ inputs.name }}" >> $GITHUB_ENV
-
     - name: "Generate SBOM, attest and sign image"
       uses: nais/salsa-action@main
       id: "salsa"
       with:
         image: ${{ inputs.registry }}/${{ inputs.name }}@${{ steps.build_push.outputs.digest }}
-        maindir: ${{ env.GOMAINDIR }}
-        byosbom: ${{ inputs.sbom }}
+        go-main-dir: ./cmd/{{ inputs.name }}
+        byo-sbom: ${{ inputs.sbom }}
         context: ${{ inputs.context }}
         google-service-account: "${{ inputs.google_service_account }}@nais-io.iam.gserviceaccount.com"
 


### PR DESCRIPTION
salsa attest -> sign and upload.

To enable verification in `salsa enabled` cluster the pod(s) must be labeled: `nais.io/salsa-verify-attestation: "true"`

The verificator ([picante](https://github.com/nais/picante)) will verify signature and upload attest (sbom with dependencies) to [salsa-storage](https://salsa.dev.dev-nais.cloud.nais.io).

Take this after easter 🐥 